### PR TITLE
Don't use full screen modal for errors

### DIFF
--- a/lib/glsl-preview-view.coffee
+++ b/lib/glsl-preview-view.coffee
@@ -49,6 +49,7 @@ class GlslPreviewView extends ScrollView
 
 		# Create the status view
 		@statusView = new StatusView()
+		@errorPanel = atom.workspace.addBottomPanel(item: @statusView, visible: false)
 
 		@bindingsView = new BindingsView()
 		@bindingsView.on('removeTexture', @removeTexture)
@@ -343,16 +344,14 @@ class GlslPreviewView extends ScrollView
 		# console.log 'error', error
 
 		if atom.config.get 'glsl-preview.showErrorMessage'
-			@notification?.dismiss()
-			@notification = atom.notifications.addError(error, dismissable: true)
 			@statusView.update "[glsl-preview] <span class='error'>#{error}</span>"
+			@errorPanel.show()
 
 	hideError: (result) ->
 		@_getActiveTab().removeClass('shader-compile-error')
 
-		@notification?.dismiss()
-
 		@statusView.update ""
+		@errorPanel.hide()
 
 	showLoading: ->
 		@loading = true

--- a/lib/glsl-preview-view.coffee
+++ b/lib/glsl-preview-view.coffee
@@ -49,7 +49,6 @@ class GlslPreviewView extends ScrollView
 
 		# Create the status view
 		@statusView = new StatusView()
-		@modalPanel = atom.workspace.addModalPanel(item: @statusView.getElement(), visible: false)
 
 		@bindingsView = new BindingsView()
 		@bindingsView.on('removeTexture', @removeTexture)
@@ -229,8 +228,6 @@ class GlslPreviewView extends ScrollView
 
 		cancelAnimationFrame( @_update )
 
-		@modalPanel.destroy()
-
 		@bindingsView.destroy()
 
 		# remove listeners
@@ -346,13 +343,14 @@ class GlslPreviewView extends ScrollView
 		# console.log 'error', error
 
 		if atom.config.get 'glsl-preview.showErrorMessage'
-			@modalPanel.show()
+			atom.notifications.addError(error)
 			@statusView.update "[glsl-preview] <span class='error'>#{error}</span>"
 
 	hideError: (result) ->
 		@_getActiveTab().removeClass('shader-compile-error')
 
-		@modalPanel.hide()
+		# TODO: remove notifications?
+
 		@statusView.update ""
 
 	showLoading: ->

--- a/lib/glsl-preview-view.coffee
+++ b/lib/glsl-preview-view.coffee
@@ -343,13 +343,14 @@ class GlslPreviewView extends ScrollView
 		# console.log 'error', error
 
 		if atom.config.get 'glsl-preview.showErrorMessage'
-			atom.notifications.addError(error)
+			@notification?.dismiss()
+			@notification = atom.notifications.addError(error, dismissable: true)
 			@statusView.update "[glsl-preview] <span class='error'>#{error}</span>"
 
 	hideError: (result) ->
 		@_getActiveTab().removeClass('shader-compile-error')
 
-		# TODO: remove notifications?
+		@notification?.dismiss()
 
 		@statusView.update ""
 


### PR DESCRIPTION
This is a small change, but a big boost to usability for me. Still a WIP, because I haven't tested much or fully dug into the notifications API. I'm opening this PR to start a discussion.

Notes:
- The notification doesn't dismiss immediately when the error is fixed.
- The notification dismisses on its own, even if the error wasn't fixed.
- Need to test: do we get spammed with notifications when "live update" is enabled?

Closes #4.