### PR TITLE
Fix treeView.serialize is not a function

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -113,6 +113,8 @@ module.exports =
 		if atom.packages.isPackageLoaded('tree-view') == true
 			treeView = atom.packages.getLoadedPackage('tree-view')
 			treeView = require(treeView.mainModulePath)
+			if !treeView.serialize
+				treeView = treeView.getTreeViewInstance()
 			packageObj = treeView.serialize()
 		if typeof packageObj != 'undefined' && packageObj != null
 			if packageObj.selectedPath


### PR DESCRIPTION
Fixes #17.

Shamelessly stole the fix from https://github.com/snowkit/atom-haxe/pull/69/commits/abbd9b92