### PR TITLE
Add Book of Shaders style to the uniforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ uniform vec2 iMouse;
 uniform float iGlobalTime;
 ```
 
+The variants `u_resolution`, `u_mouse` and `u_time` can also be used to match the style found in [The Book of Shaders](http://thebookofshaders.com/).
+
 ## Shader errors
 
 If the shader can't compile then the tab will subtly highlight in red.

--- a/lib/glsl-preview-view.coffee
+++ b/lib/glsl-preview-view.coffee
@@ -146,8 +146,8 @@ class GlslPreviewView extends ScrollView
 
 		@uniforms.iResolution.value.x = width * ratio
 		@uniforms.iResolution.value.y = height * ratio
-		@uniforms.u_resolution.value.x = width * ratio
-		@uniforms.u_resolution.value.y = height * ratio
+		@uniforms.u_resolution.value.x = @uniforms.iResolution.value.x
+		@uniforms.u_resolution.value.y = @uniforms.iResolution.value.y
 
 		@renderer.setSize( width, height )
 
@@ -159,8 +159,8 @@ class GlslPreviewView extends ScrollView
 
 		@uniforms.iMouse.value.x = event.offsetX / width
 		@uniforms.iMouse.value.y = 1 - (event.offsetY / height)
-		@uniforms.u_mouse.value.x = event.offsetX / width
-		@uniforms.u_mouse.value.y = 1 - (event.offsetY / height)
+		@uniforms.u_mouse.value.x = @uniforms.iMouse.value.x
+		@uniforms.u_mouse.value.y = @uniforms.iMouse.value.y
 
 	_update: =>
 
@@ -169,7 +169,7 @@ class GlslPreviewView extends ScrollView
 		requestAnimationFrame( @_update )
 
 		@uniforms.iGlobalTime.value = @clock.getElapsedTime()
-		@uniforms.u_time.value = @clock.getElapsedTime()
+		@uniforms.u_time.value = @uniforms.iGlobalTime.value
 
 		@renderer.render( @scene, @camera )
 

--- a/lib/glsl-preview-view.coffee
+++ b/lib/glsl-preview-view.coffee
@@ -75,6 +75,9 @@ class GlslPreviewView extends ScrollView
 			iGlobalTime: { type: "f", value: 1.0 },
 			iResolution: { type: "v2", value: new THREE.Vector2() },
 			iMouse: { type: "v2", value: new THREE.Vector2() }
+			u_time: { type: "f", value: 1.0 },
+			u_resolution: { type: "v2", value: new THREE.Vector2() },
+			u_mouse: { type: "v2", value: new THREE.Vector2() }
 		}
 
 		@mesh1 = null
@@ -143,6 +146,8 @@ class GlslPreviewView extends ScrollView
 
 		@uniforms.iResolution.value.x = width * ratio
 		@uniforms.iResolution.value.y = height * ratio
+		@uniforms.u_resolution.value.x = width * ratio
+		@uniforms.u_resolution.value.y = height * ratio
 
 		@renderer.setSize( width, height )
 
@@ -154,6 +159,8 @@ class GlslPreviewView extends ScrollView
 
 		@uniforms.iMouse.value.x = event.offsetX / width
 		@uniforms.iMouse.value.y = 1 - (event.offsetY / height)
+		@uniforms.u_mouse.value.x = event.offsetX / width
+		@uniforms.u_mouse.value.y = 1 - (event.offsetY / height)
 
 	_update: =>
 
@@ -162,6 +169,7 @@ class GlslPreviewView extends ScrollView
 		requestAnimationFrame( @_update )
 
 		@uniforms.iGlobalTime.value = @clock.getElapsedTime()
+		@uniforms.u_time.value = @clock.getElapsedTime()
 
 		@renderer.render( @scene, @camera )
 
@@ -177,6 +185,9 @@ class GlslPreviewView extends ScrollView
 			'uniform vec2 iResolution;'
 			'uniform vec2 iMouse;'
 			'uniform float iGlobalTime;'
+			'uniform vec2 u_resolution;'
+			'uniform vec2 u_mouse;'
+			'uniform float u_time;'
 		].join('\n')
 
 	_fragmentShader: ->


### PR DESCRIPTION
Totally not necessary, more of a test to try editing this atom package. 

That being said, it *is* continually annoying that this tool, the Book of Shaders and Shadertoy all use slightly different syntax. Allowing for both here would facilitate copy/pasting at the small price of slightly muddying the namespace.