### PR TITLE
Remove serialization and auto-activate

### DIFF
--- a/lib/glsl-preview-view.js
+++ b/lib/glsl-preview-view.js
@@ -244,14 +244,6 @@ module.exports = class GlslPreviewView {
     }
   }
 
-  serialize() {
-    return {
-      deserializer: "GlslPreviewView",
-      filePath: this.getPath() || this.filePath,
-      editorId: this.editorId,
-    };
-  }
-
   destroy() {
     this.IS_DESTROYED = true;
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -1,20 +1,36 @@
 const url = require("url");
-const fs = require("fs-plus");
 
-let GlslPreviewView = null; // Defer until used
-
-function createGlslPreviewView(state) {
-  if (!GlslPreviewView) {
-    GlslPreviewView = require("./glsl-preview-view"); // eslint-disable-line
-  }
-  return new GlslPreviewView(state);
-}
+const GlslPreviewView = require("./glsl-preview-view");
 
 function isGlslPreviewView(object) {
-  if (!GlslPreviewView) {
-    GlslPreviewView = require("./glsl-preview-view"); // eslint-disable-line
-  }
   return object instanceof GlslPreviewView;
+}
+
+function opener(uriToOpen) {
+  let parsedURL;
+  try {
+    parsedURL = url.parse(uriToOpen);
+  } catch (error) {
+    return null;
+  }
+
+  if (parsedURL.protocol !== "glsl-preview:") {
+    return null;
+  }
+
+  let pathname = parsedURL.pathname;
+  try {
+    if (pathname) {
+      pathname = decodeURI(pathname);
+    }
+  } catch (error) {
+    return null;
+  }
+
+  if (parsedURL.host === "editor") {
+    return new GlslPreviewView({ editorId: pathname.substring(1) });
+  }
+  return new GlslPreviewView({ filePath: pathname });
 }
 
 module.exports = {
@@ -50,16 +66,6 @@ module.exports = {
   },
 
   activate() {
-    atom.deserializers.add({
-      name: "GlslPreviewView",
-      deserialize(state) {
-        if (state.editorId || fs.isFileSync(state.filePath)) {
-          return createGlslPreviewView(state);
-        }
-        return null;
-      },
-    });
-
     // TODO: CompositeDisposable for these?
     atom.commands.add("atom-workspace", "glsl-preview:toggle", this.toggle.bind(this));
     atom.commands.add("atom-workspace", "glsl-preview:addTexture", this.addTexture.bind(this));
@@ -67,34 +73,7 @@ module.exports = {
     atom.commands.add(".tree-view .file", "glsl-preview:addTextureTreeView", this.addTextureTreeView.bind(this));
     atom.commands.add(".tree-view .file .name[data-name$=\\.glsl]", "glsl-preview:preview-file", this.previewFile.bind(this));
 
-    atom.workspace.addOpener((uriToOpen) => {
-      let parsedURL;
-      try {
-        parsedURL = url.parse(uriToOpen);
-      } catch (error) {
-        return null;
-      }
-
-      if (parsedURL.protocol !== "glsl-preview:") {
-        return null;
-      }
-
-      let pathname = parsedURL.pathname;
-      try {
-        if (pathname) {
-          pathname = decodeURI(pathname);
-        }
-      } catch (error) {
-        return null;
-      }
-
-      if (parsedURL.host === "editor") {
-        return createGlslPreviewView({ editorId: pathname.substring(1) });
-      }
-      return createGlslPreviewView({ filePath: pathname });
-    });
-
-    this.toggle();
+    atom.workspace.addOpener(opener);
   },
 
   toggle() {


### PR DESCRIPTION
I felt that this was adding a huge level of complexity and a little buginess, without a lot of value. I may add it back later after getting a better handle on everything else.

Previously, glsl-preview would remember the shaders you were running the last time you had this project open, and attempt to reopen them. It would also try to automatically activate on the active tab. I removed both behaviors.