### PR TITLE
Fix test uniform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- [#51](https://github.com/fordhurley/atom-glsl-preview/issues/51): Fix "uniform
+  location" error when uniform is defined but unused.
+
 # v2.0.0
 
 - Upgrade shader-canvas to v0.8.0, with no dependency on Threejs, for a much

--- a/lib/glsl-preview-view.js
+++ b/lib/glsl-preview-view.js
@@ -40,11 +40,6 @@ const precisionPrefix = `
   precision highp float;
 `;
 
-function testUniform(type, name, source) {
-  const re = new RegExp(`^\\s*uniform\\s+${type}\\s+${name}`, "m");
-  return re.test(source);
-}
-
 function parseTextureDirectives(source) {
   // Looking for lines of the form:
   // uniform sampler2D foo; // ../textures/foo.png
@@ -249,28 +244,28 @@ module.exports = class GlslPreviewView {
   }
 
   setResolutionUniform() {
-    if (testUniform("vec2", "u_resolution", this.source)) {
+    if (this.shader.testUniform("u_resolution")) {
       this.shader.setUniform("u_resolution", this.shader.getResolution());
     }
-    if (testUniform("vec2", "iResolution", this.source)) {
+    if (this.shader.testUniform("iResolution")) {
       this.shader.setUniform("iResolution", this.shader.getResolution());
     }
   }
 
   setTimeUniform(timeSeconds) {
-    if (testUniform("float", "u_time", this.source)) {
+    if (this.shader.testUniform("u_time")) {
       this.shader.setUniform("u_time", timeSeconds);
     }
-    if (testUniform("float", "iGlobalTime", this.source)) {
+    if (this.shader.testUniform("iGlobalTime")) {
       this.shader.setUniform("iGlobalTime", timeSeconds);
     }
   }
 
   setMouseUniform(x, y) {
-    if (testUniform("vec2", "u_mouse", this.source)) {
+    if (this.shader.testUniform("u_mouse")) {
       this.shader.setUniform("u_mouse", [x, y]);
     }
-    if (testUniform("vec2", "iMouse", this.source)) {
+    if (this.shader.testUniform("iMouse")) {
       this.shader.setUniform("iMouse", [x, y]);
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1157,9 +1157,9 @@
       "dev": true
     },
     "shader-canvas": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/shader-canvas/-/shader-canvas-0.8.0.tgz",
-      "integrity": "sha512-bXjEHHWp3HO/HPTQyU/slUBn/fTCz+NiQiARBFToPeAo7KakyPWqAqQ7LJJ2ijag95t6jJcgzKRiQr84UhdCOA=="
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/shader-canvas/-/shader-canvas-0.8.1.tgz",
+      "integrity": "sha512-B9QquXTgNduhEsbRVNvpTvCqm/3CMqc6iDBKmHRB+ZU6xXBz4sXOESVg7C9UZFdG6VfFD0P+C3ECzCpOqyxmVQ=="
     },
     "shallow-copy": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "glslify": "^7.0.0",
     "interactjs": "^1.2.9",
-    "shader-canvas": "^0.8.0",
+    "shader-canvas": "^0.8.1",
     "underscore": "^1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #51 by asking webgl if the uniform is used before trying to set it. Previously, it was just looking for the uniform being defined in the source, but unless it was also read in the shader this would cause a "uniform location not found" error.